### PR TITLE
Fix: POST /messages lacks server-side validation for empty recipients, content, or invalid time 

### DIFF
--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"gopkg.in/validator.v2"
@@ -63,6 +64,19 @@ func (s *service) GetAllMessages(ctx context.Context, input GetAllMessagesInput)
 }
 
 func (s *service) SendMessage(ctx context.Context, input ScheduleMessageInput) error {
+
+	if len(input.RecipientNumbers) == 0 {
+		return fmt.Errorf("recipient numbers cannot be empty")
+	}
+
+	if len(input.Content) == 0 {
+		return fmt.Errorf("message content cannot be empty")
+	}
+
+	if input.ScheduledSendingAt <= 0 || input.ScheduledSendingAt < time.Now().Unix() {
+		return fmt.Errorf("scheduled time must be in the future")
+	}
+
 	msg := Message{
 		ID:                 uuid.New().String(),
 		Content:            input.Content,

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSendMessage(t *testing.T) {
+	// 1. Setup your service (mocking dependencies if necessary)
+	svc := &service{
+		// Add your storage/scheduler mocks here
+	}
+
+	// 2. Define the Test Table
+	tests := []struct {
+		name          string
+		input         ScheduleMessageInput
+		expectedError string
+	}{
+		{
+			name: "Empty Recipients",
+			input: ScheduleMessageInput{
+				RecipientNumbers:   []string{}, // Empty
+				Content:            "Hello",
+				ScheduledSendingAt: time.Now().Add(time.Hour).Unix(),
+			},
+			expectedError: "recipient numbers cannot be empty",
+		},
+		{
+			name: "Empty Content",
+			input: ScheduleMessageInput{
+				RecipientNumbers:   []string{"12345"},
+				Content:            "", // Empty
+				ScheduledSendingAt: time.Now().Add(time.Hour).Unix(),
+			},
+			expectedError: "message content cannot be empty",
+		},
+		{
+			name: "Past Timestamp",
+			input: ScheduleMessageInput{
+				RecipientNumbers:   []string{"12345"},
+				Content:            "Hello",
+				ScheduledSendingAt: time.Now().Add(-time.Hour).Unix(), // 1 hour ago
+			},
+			expectedError: "scheduled time must be in the future",
+		},
+		{
+			name: "Zero Timestamp",
+			input: ScheduleMessageInput{
+				RecipientNumbers:   []string{"12345"},
+				Content:            "Hello",
+				ScheduledSendingAt: 0, // The "Zero" problem
+			},
+			expectedError: "scheduled time must be in the future",
+		},
+		{
+			name: "Valid",
+			input: ScheduleMessageInput{
+				RecipientNumbers:   []string{"12345"},
+				Content:            "Hello",
+				ScheduledSendingAt: time.Now().Add(time.Hour).Unix(), // The "Zero" problem
+			},
+			expectedError: "",
+		},
+	}
+
+	// 3. Run the tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := svc.SendMessage(context.Background(), tc.input)
+
+			if tc.expectedError == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got: %v", err)
+				}
+			}
+
+			// Check if we got an error when we expected one
+			if err == nil {
+				t.Fatal("expected an error but got none")
+			}
+
+			// Check if the error message is what we expected
+			if err.Error() != tc.expectedError {
+				t.Errorf("expected error %q, got %q", tc.expectedError, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR Adds Validation before API call to check:

*Non-empty recipients
*Non-empty content
*Sensible scheduling time 