### PR TITLE
ci: add GitHub Actions workflow for tests and static checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./... -count=1 -v
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"


### PR DESCRIPTION
## Issue

Closes #23

## Root Cause

The project had no automated CI to verify that contributions pass tests before merge, relying only on manual `make test` execution as documented in CONTRIBUTING.md.

## Changes

- Created `.github/workflows/ci.yml` with GitHub Actions workflow
- Runs `go test ./... -count=1 -v` on all PRs and pushes to main
- Includes static analysis: `go vet ./...` and `gofmt -l .`
- Path filters to skip doc-only changes (docs/, *.md files)
- Uses `go-version-file: go.mod` to enforce Go 1.25.0 across CI and contributors

## Testing

Confirm testing and no breaking changes.

- [x] Ran `make test` from the repository root
- [ ] Added or updated tests so new functionality is covered (or explained below if tests are not applicable)
- [ ] (Optional) Local Docker smoke test per [README](https://github.com/ghazlabs/wa-scheduler/blob/main/README.md)
- [x] No breaking changes, or documented below if any

Workflow tested locally and ready for GitHub Actions execution.
No new functionality