### PR TITLE
ci: ignore docs and markdown file only change for test ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: test
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
 
 jobs:
   test:


### PR DESCRIPTION
## Issue

Adjusted this comment https://github.com/ghazlabs/wa-scheduler/pull/29#issuecomment-4494187169

## Root Cause

No test CI filtering for any commit to the main branch PR

## Changes

Updated the test CI to ignore the `docs` folder and the markdown file change only

## Testing

Confirm testing and no breaking changes.

- [x] Ran `make test` from the repository root
- [ ] Added or updated tests so new functionality is covered (or explained below if tests are not applicable)
- [ ] (Optional) Local Docker smoke test per [README](https://github.com/ghazlabs/wa-scheduler/blob/main/README.md)
- [x] No breaking changes, or documented below if any

No new functionality
