### PR TITLE
fix(core): reject retry for non-failed messages

### DIFF
--- a/internal/core/error.go
+++ b/internal/core/error.go
@@ -2,11 +2,35 @@ package core
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 )
 
 var (
-	ErrCodeBadRequest    = errors.New("ERR_BAD_REQUEST")
-	ErrCodeInternalError = errors.New("ERR_INTERNAL_ERROR")
-	ErrSessionExpired    = errors.New("ERR_SESSION_EXPIRED")
-	ErrMessageNotFound   = errors.New("ERR_MESSAGE_NOT_FOUND")
+	ErrCodeBadRequest           = errors.New("ERR_BAD_REQUEST")
+	ErrCodeInternalError        = errors.New("ERR_INTERNAL_ERROR")
+	ErrSessionExpired           = errors.New("ERR_SESSION_EXPIRED")
+	ErrMessageNotFound          = errors.New("ERR_MESSAGE_NOT_FOUND")
+	ErrCannotRetryActiveMessage = errors.New("ERR_CANNOT_RETRY_ACTIVE_MESSAGE")
 )
+
+// CannotRetryMessageError indicates a retry was requested for a message that is not failed.
+type CannotRetryMessageError struct {
+	CurrentStatus MessageStatus
+}
+
+func NewCannotRetryMessageError(status MessageStatus) *CannotRetryMessageError {
+	return &CannotRetryMessageError{CurrentStatus: status}
+}
+
+func (e *CannotRetryMessageError) Error() string {
+	return fmt.Sprintf(
+		"Cannot retry message: current status is '%s'. Only '%s' messages can be retried.",
+		strings.ToUpper(string(e.CurrentStatus)),
+		strings.ToUpper(string(MessageStatusFailed)),
+	)
+}
+
+func (e *CannotRetryMessageError) Is(target error) bool {
+	return target == ErrCannotRetryActiveMessage
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -91,6 +91,9 @@ func (s *service) RetryMessage(ctx context.Context, input RetryMessageInput) err
 	if msg == nil {
 		return ErrMessageNotFound
 	}
+	if msg.Status != MessageStatusFailed {
+		return NewCannotRetryMessageError(msg.Status)
+	}
 	msg.ScheduledSendingAt = input.ScheduledSendingAt
 
 	err = s.Scheduler.RetryMessage(ctx, *msg)

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type mockStorage struct {
+	message *Message
+	getErr  error
+}
+
+func (m *mockStorage) GetAllMessages(ctx context.Context, input GetAllMessagesInput) ([]Message, error) {
+	return nil, nil
+}
+
+func (m *mockStorage) SaveMessage(ctx context.Context, message Message) error {
+	return nil
+}
+
+func (m *mockStorage) UpdateMessage(ctx context.Context, message Message) error {
+	return nil
+}
+
+func (m *mockStorage) GetMessage(ctx context.Context, id string) (*Message, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	return m.message, nil
+}
+
+type mockScheduler struct {
+	retryCalled bool
+	retryErr    error
+}
+
+func (m *mockScheduler) ScheduleMessage(ctx context.Context, message Message) error {
+	return nil
+}
+
+func (m *mockScheduler) RetryMessage(ctx context.Context, msg Message) error {
+	m.retryCalled = true
+	return m.retryErr
+}
+
+func newRetryTestService(t *testing.T, status MessageStatus) (Service, *mockScheduler) {
+	t.Helper()
+
+	scheduler := &mockScheduler{}
+	svc, err := NewService(ServiceConfig{
+		Storage: &mockStorage{
+			message: &Message{ID: "msg-1", Status: status},
+		},
+		Scheduler: scheduler,
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	return svc, scheduler
+}
+
+func callRetryMessage(t *testing.T, svc Service) error {
+	t.Helper()
+	return svc.RetryMessage(context.Background(), RetryMessageInput{
+		ID:                 "msg-1",
+		ScheduledSendingAt: 12345,
+	})
+}
+
+func assertRetrySucceeded(t *testing.T, scheduler *mockScheduler, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("RetryMessage() error = %v, want nil", err)
+	}
+	if !scheduler.retryCalled {
+		t.Fatal("expected scheduler.RetryMessage to be called")
+	}
+}
+
+func assertRetryRejected(t *testing.T, scheduler *mockScheduler, err error, wantErrIs error, wantErrText string) {
+	t.Helper()
+	if scheduler.retryCalled {
+		t.Fatal("scheduler.RetryMessage should not be called for non-failed messages")
+	}
+	if !errors.Is(err, wantErrIs) {
+		t.Fatalf("RetryMessage() errors.Is = %v, want %v", err, wantErrIs)
+	}
+	if err.Error() != wantErrText {
+		t.Fatalf("RetryMessage() error = %q, want %q", err.Error(), wantErrText)
+	}
+}
+
+func TestRetryMessage_FailedStatusCanBeRetried(t *testing.T) {
+	t.Parallel()
+
+	svc, scheduler := newRetryTestService(t, MessageStatusFailed)
+	err := callRetryMessage(t, svc)
+	assertRetrySucceeded(t, scheduler, err)
+}
+
+func TestRetryMessage_SentStatusCannotBeRetried(t *testing.T) {
+	t.Parallel()
+
+	svc, scheduler := newRetryTestService(t, MessageStatusSent)
+	err := callRetryMessage(t, svc)
+	assertRetryRejected(t, scheduler, err, ErrCannotRetryActiveMessage,
+		"Cannot retry message: current status is 'SENT'. Only 'FAILED' messages can be retried.")
+}
+
+func TestRetryMessage_ScheduledStatusCannotBeRetried(t *testing.T) {
+	t.Parallel()
+
+	svc, scheduler := newRetryTestService(t, MessageStatusScheduled)
+	err := callRetryMessage(t, svc)
+	assertRetryRejected(t, scheduler, err, ErrCannotRetryActiveMessage,
+		"Cannot retry message: current status is 'SCHEDULED'. Only 'FAILED' messages can be retried.")
+}
+
+func TestRetryMessage_MessageNotFound(t *testing.T) {
+	t.Parallel()
+
+	scheduler := &mockScheduler{}
+	svc, err := NewService(ServiceConfig{
+		Storage:   &mockStorage{message: nil},
+		Scheduler: scheduler,
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	err = svc.RetryMessage(context.Background(), RetryMessageInput{ID: "missing"})
+	if !errors.Is(err, ErrMessageNotFound) {
+		t.Fatalf("RetryMessage() errors.Is = %v, want ErrMessageNotFound", err)
+	}
+	if scheduler.retryCalled {
+		t.Fatal("scheduler.RetryMessage should not be called when message is missing")
+	}
+}

--- a/internal/driver/error.go
+++ b/internal/driver/error.go
@@ -47,3 +47,19 @@ func NewInvalidCredsError() *Error {
 		Message:    "invalid credentials",
 	}
 }
+
+func NewConflictError(msg string) *Error {
+	return &Error{
+		StatusCode: http.StatusConflict,
+		Err:        "ERR_CONFLICT",
+		Message:    msg,
+	}
+}
+
+func NewNotFoundError(msg string) *Error {
+	return &Error{
+		StatusCode: http.StatusNotFound,
+		Err:        "ERR_MESSAGE_NOT_FOUND",
+		Message:    msg,
+	}
+}

--- a/internal/driver/model.go
+++ b/internal/driver/model.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ghazlabs/wa-scheduler/internal/core"
 	"github.com/go-chi/render"
 )
 
@@ -33,7 +34,21 @@ func NewSuccessResp(data interface{}) *RespBody {
 
 func NewErrorResp(err error) *RespBody {
 	var restErr *Error
-	if !errors.As(err, &restErr) {
+	if errors.As(err, &restErr) {
+		return &RespBody{
+			StatusCode: restErr.StatusCode,
+			OK:         false,
+			Err:        restErr.Err,
+			Message:    restErr.Message,
+		}
+	}
+
+	var cannotRetry *core.CannotRetryMessageError
+	if errors.As(err, &cannotRetry) {
+		restErr = NewConflictError(cannotRetry.Error())
+	} else if errors.Is(err, core.ErrMessageNotFound) {
+		restErr = NewNotFoundError("message not found")
+	} else {
 		restErr = NewInternalServerError(err)
 	}
 

--- a/internal/driver/model_test.go
+++ b/internal/driver/model_test.go
@@ -1,0 +1,38 @@
+package driver
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ghazlabs/wa-scheduler/internal/core"
+)
+
+func TestNewErrorResp_CannotRetryMapsToConflict(t *testing.T) {
+	t.Parallel()
+
+	resp := NewErrorResp(core.NewCannotRetryMessageError(core.MessageStatusSent))
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+	if resp.Err != "ERR_CONFLICT" {
+		t.Fatalf("Err = %q, want ERR_CONFLICT", resp.Err)
+	}
+	wantMsg := "Cannot retry message: current status is 'SENT'. Only 'FAILED' messages can be retried."
+	if resp.Message != wantMsg {
+		t.Fatalf("Message = %q, want %q", resp.Message, wantMsg)
+	}
+}
+
+func TestNewErrorResp_MessageNotFoundMapsToNotFound(t *testing.T) {
+	t.Parallel()
+
+	resp := NewErrorResp(core.ErrMessageNotFound)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+	if resp.Err != "ERR_MESSAGE_NOT_FOUND" {
+		t.Fatalf("Err = %q, want ERR_MESSAGE_NOT_FOUND", resp.Err)
+	}
+}


### PR DESCRIPTION
## Issue

Which issue does this PR address?

Fixes retry validation for POST /messages/{id}/retry (messages in sent or scheduled state could be retried, causing duplicate deliveries and incorrect telemetry).

## Root Cause

What caused the problem?

RetryMessage in internal/core/service.go loaded the message and called the scheduler without checking msg.Status. The REST API documents that retries are only for failed messages, but that rule was never enforced in the service layer. Retrying a sent or scheduled message incremented RetriedCount, rescheduled the job, and could send the same content again.

## Changes

What did you change to fix it?

Changes
internal/core/service.go — After fetching the message, return CannotRetryMessageError when msg.Status != MessageStatusFailed; only then update ScheduledSendingAt and call the scheduler.
internal/core/error.go — Added ErrCannotRetryActiveMessage and CannotRetryMessageError with a clear, status-specific error message.
internal/driver/model.go — Map CannotRetryMessageError to HTTP 409 Conflict (ERR_CONFLICT) in NewErrorResp; map ErrMessageNotFound to 404 (was previously treated as 500).
internal/driver/error.go — Added NewConflictError and NewNotFoundError.
internal/core/service_test.go — Unit tests for failed (allowed), sent/scheduled (rejected), and not-found paths.
internal/driver/model_test.go — Unit tests for 409 and 404 error mapping.
Internal scheduler retries on publish failure are unchanged (they use GoCronScheduler.RetryMessage directly).

## Testing

 Confirm testing and no breaking changes.

 Ran make test from the repository root

 Added or updated tests so new functionality is covered (or explained below if tests are not applicable)

 (Optional) Local Docker smoke test per [README](https://github.com/ghazlabs/wa-scheduler/blob/main/README.md)

 No breaking changes, or documented below if any

Tests added: internal/core/service_test.go, internal/driver/model_test.go (retry guard + HTTP status mapping).

Manual checks (optional):

Create or identify a failed message → POST /messages/{id}/retry → expect 200.
Retry a sent or scheduled message → expect 409 with message explaining only failed messages can be retried.
Retry a non-existent id → expect 404.
Breaking change (intentional): Clients that retried non-failed messages previously received 200; they now receive 409 Conflict. This matches documented API behavior and prevents duplicate sends.
